### PR TITLE
Fix: Escape special characters in tab titles to prevent block crash

### DIFF
--- a/src/tabs/render.php
+++ b/src/tabs/render.php
@@ -73,7 +73,7 @@ $data_context = [
 ?>
 <div <?php echo wp_kses_data($wrapper_attributes); ?>
     data-wp-interactive="blablablocks-tabs"
-    data-wp-context='<?php echo wp_json_encode($data_context); ?>'
+	data-wp-context='<?php echo esc_attr(wp_json_encode($data_context)); ?>'
     data-wp-init="callbacks.initTabs"
     data-wp-watch="callbacks.updateTabBorders">
 


### PR DESCRIPTION
## Summary
Fixes #29

This PR fixes a bug where the tabs block crashes when a tab title contains special characters (e.g., apostrophe `'`, quotes `"`, etc.). 

## Problem
The `data-wp-context` attribute in `src/tabs/render. php` was not properly escaping the JSON output:

```php
data-wp-context='<?php echo wp_json_encode($data_context); ?>'
```

When a tab title like `L'onglet` was used, the generated HTML would break:
```html
data-wp-context='{"tabs":[{"label":"L'onglet"... }]}'
```

The apostrophe in the title prematurely closes the HTML attribute, causing the block to crash. 

## Solution
Wrap `wp_json_encode()` with `esc_attr()` to properly escape special characters:

```php
data-wp-context='<?php echo esc_attr(wp_json_encode($data_context)); ?>'
```

This ensures that special characters are encoded as HTML entities (`'` → `&#039;`) in the attribute, while the browser automatically decodes them when parsing, so the title displays correctly on screen. 

## Testing
1. Create a tabs block in the editor
2. Set a tab title with special characters (e.g., `It's working! ` or `Test "quotes"`)
3.  Save and view the page on the frontend
4. ✅ The block should render correctly without crashing
5. ✅ The tab title should display the special characters properly